### PR TITLE
Fix repository clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 1. **Clone the repo:**
 
    ```bash
-   git clone https://github.com/hsraktu17/periskope.git
-   cd periskope
+   git clone https://github.com/hsraktu17/talkative.git
+   cd talkative
    ```
 
 2. **Install dependencies:**


### PR DESCRIPTION
## Summary
- update README clone command to match the talkative repo

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dda713a08328a6ed1d40e00af723